### PR TITLE
add hanazonochateau.net to otaku links

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@
       <h2>Otaku Links</h2>
       <ul>
         <li>Cra2yVLSI: <a href="https://vlsi.jp/">vlsi.jp</a></li>
+        <li>花園シャトー107号室: <a href="https://hanazonochateau.net/">hanazonochateau.net</a></li>
       </ul>
     </section>
 


### PR DESCRIPTION
リンクコーナーに自サイト（ https://hanazonochateau.net/ ）のリンクを追加しました。
よろしくお願いします。