### PR TITLE
rover-sim: クエリパラメータによる URL 共有

### DIFF
--- a/sandbox/rover-sim/app.js
+++ b/sandbox/rover-sim/app.js
@@ -12,7 +12,17 @@
 
 import { compileWorld, compileFirmware, Simulation, sampleGround, toHex } from './sim.js';
 import { CodeEditor } from './highlight.js';
-import { SAMPLES } from './samples.js';
+import { SAMPLES, findSample } from './samples.js';
+import {
+  encodeText,
+  decodeText,
+  buildShareUrl,
+  PARAM_WORLD,
+  PARAM_FIRMWARE,
+  PARAM_SAMPLE,
+  PARAM_SPEED,
+  PARAM_VIEW,
+} from './share.js';
 
 const STORAGE_WORLD = 'rover-sim.world';
 const STORAGE_FIRMWARE = 'rover-sim.firmware';
@@ -66,6 +76,7 @@ export function initApp() {
   const btnFull = $('btn-full');
   const btnExec = $('btn-exec');
   const selSample = $('sel-sample');
+  const btnShare = $('btn-share');
   const selSpeed = $('sel-speed');
   const selView = $('sel-view');
   const splitter = $('splitter');
@@ -448,15 +459,25 @@ export function initApp() {
     rebuildMonitor();
   }
 
-  /** エディタのスクリプトを読み込み、最初から実行する */
-  function execScripts({ silent = false } = {}) {
+  /**
+   * エディタのスクリプトを読み込み、最初から実行する。
+   * save: false のとき localStorage を上書きしない (共有 URL からの読み込み用)。
+   */
+  function execScripts({ silent = false, save = true } = {}) {
     const worldSrc = worldEditor.getValue();
     const firmwareSrc = firmwareEditor.getValue();
     try {
       buildSim(worldSrc, firmwareSrc);
       lastSources = { world: worldSrc, firmware: firmwareSrc };
-      storageSet(STORAGE_WORLD, worldSrc);
-      storageSet(STORAGE_FIRMWARE, firmwareSrc);
+      if (save) {
+        storageSet(STORAGE_WORLD, worldSrc);
+        storageSet(STORAGE_FIRMWARE, firmwareSrc);
+        // 内容が変わったので古い共有パラメータを URL から外す
+        const sp = new URLSearchParams(location.search);
+        if (sp.has(PARAM_WORLD) || sp.has(PARAM_FIRMWARE) || sp.has(PARAM_SAMPLE)) {
+          history.replaceState(null, '', location.pathname);
+        }
+      }
       setRunning(true);
       if (!silent) pushConsole('スクリプトを読み込み、実行を開始しました', 'ok');
       return true;
@@ -464,6 +485,88 @@ export function initApp() {
       pushConsole(`エラー: ${e.message}`, 'error');
       return false;
     }
+  }
+
+  /**
+   * 現在のエディタ内容と設定を載せた共有 URL を作り、コピーする。
+   * 単純な設定は素のクエリ、コードは world / firmware に個別の base64url。
+   * 未編集のサンプルそのままなら sample=<id> だけを載せる。
+   */
+  async function shareCurrent() {
+    try {
+      const worldSrc = worldEditor.getValue();
+      const firmwareSrc = firmwareEditor.getValue();
+      const settings = { [PARAM_SPEED]: speed, [PARAM_VIEW]: viewMode };
+
+      const sample = findSample(worldSrc, firmwareSrc);
+      const params = sample
+        ? { [PARAM_SAMPLE]: sample.id, ...settings }
+        : {
+            ...settings,
+            [PARAM_WORLD]: await encodeText(worldSrc),
+            [PARAM_FIRMWARE]: await encodeText(firmwareSrc),
+          };
+
+      const url = buildShareUrl(location.href, params);
+      history.replaceState(null, '', url);
+      if (url.length > 8000) {
+        pushConsole(`注意: 共有 URL が長め (${url.length} 文字) です。一部のサービスでは切れる可能性があります`, 'info');
+      }
+      try {
+        await navigator.clipboard.writeText(url);
+        pushConsole(`共有 URL をコピーしました (${url.length} 文字)`, 'ok');
+      } catch {
+        pushConsole('共有 URL をアドレスバーに反映しました (コピーは手動でどうぞ)', 'info');
+      }
+    } catch (e) {
+      pushConsole(`共有 URL の生成に失敗しました: ${e.message}`, 'error');
+    }
+  }
+
+  /** 起動時: 共有 URL があればスクリプトと設定を復元して実行する */
+  async function initFromUrl() {
+    const sp = new URLSearchParams(location.search);
+
+    // 単純な設定はコードの有無に関わらず反映する
+    if ([1, 2, 4, 8].includes(+sp.get(PARAM_SPEED))) {
+      speed = +sp.get(PARAM_SPEED);
+      selSpeed.value = String(speed);
+    }
+    const view = sp.get(PARAM_VIEW);
+    if (view === 'temp' || view === 'color') {
+      viewMode = view;
+      selView.value = view;
+    }
+
+    try {
+      if (sp.has(PARAM_WORLD) || sp.has(PARAM_FIRMWARE)) {
+        if (sp.has(PARAM_WORLD)) worldEditor.setValue(await decodeText(sp.get(PARAM_WORLD)));
+        if (sp.has(PARAM_FIRMWARE)) firmwareEditor.setValue(await decodeText(sp.get(PARAM_FIRMWARE)));
+        const ok = execScripts({ silent: true, save: false });
+        pushConsole(
+          ok ? '共有 URL からスクリプトを読み込みました' : '共有 URL のスクリプトにエラーがあります',
+          ok ? 'ok' : 'error'
+        );
+        return true;
+      }
+
+      const sampleId = sp.get(PARAM_SAMPLE);
+      if (sampleId) {
+        const sample = SAMPLES.find((s) => s.id === sampleId);
+        if (!sample) {
+          pushConsole(`共有 URL のサンプルが見つかりません: ${sampleId}`, 'error');
+          return false;
+        }
+        worldEditor.setValue(sample.world);
+        firmwareEditor.setValue(sample.firmware);
+        execScripts({ silent: true, save: false });
+        pushConsole(`共有 URL からサンプル「${sample.name}」を読み込みました`, 'ok');
+        return true;
+      }
+    } catch (e) {
+      pushConsole(`共有 URL の読み込みに失敗しました: ${e.message}`, 'error');
+    }
+    return false;
   }
 
   /**
@@ -490,6 +593,7 @@ export function initApp() {
   btnPause.addEventListener('click', () => setRunning(!running));
   btnReset.addEventListener('click', resetSim);
   btnExec.addEventListener('click', () => execScripts());
+  btnShare.addEventListener('click', () => shareCurrent());
   selSample.addEventListener('change', () => {
     const sample = SAMPLES.find((s) => s.id === selSample.value);
     selSample.value = ''; // プレースホルダに戻す
@@ -497,7 +601,10 @@ export function initApp() {
     worldEditor.setValue(sample.world);
     firmwareEditor.setValue(sample.firmware);
     pushConsole(`サンプル「${sample.name}」を読み込みました`, 'info');
-    execScripts({ silent: true });
+    if (execScripts({ silent: true })) {
+      // サンプルを選んだだけの状態は sample= だけの URL にしておく
+      history.replaceState(null, '', buildShareUrl(location.href, { [PARAM_SAMPLE]: sample.id }));
+    }
   });
   selSpeed.addEventListener('change', () => {
     speed = Number(selSpeed.value);
@@ -591,13 +698,18 @@ export function initApp() {
   }
 
   // ---- 起動 ----
-  if (!execScripts({ silent: true })) {
-    // 保存されたスクリプトが壊れている場合はサンプルへフォールバック
-    worldEditor.setValue(SAMPLES[0].world);
-    firmwareEditor.setValue(SAMPLES[0].firmware);
-    execScripts({ silent: true });
-  }
-  pushConsole('▶ 実行 (Ctrl+Enter) でスクリプトを読み込んで実行 / Space で一時停止・再開', 'info');
-  selectTab('firmware');
-  requestAnimationFrame(frame);
+  (async () => {
+    // 優先順: 共有 URL > localStorage > サンプル
+    if (!(await initFromUrl())) {
+      if (!execScripts({ silent: true, save: false })) {
+        // 保存されたスクリプトが壊れている場合はサンプルへフォールバック
+        worldEditor.setValue(SAMPLES[0].world);
+        firmwareEditor.setValue(SAMPLES[0].firmware);
+        execScripts({ silent: true, save: false });
+      }
+    }
+    pushConsole('▶ 実行 (Ctrl+Enter) でスクリプトを読み込んで実行 / Space で一時停止・再開 / 🔗 共有 で URL 共有', 'info');
+    selectTab('firmware');
+    requestAnimationFrame(frame);
+  })();
 }

--- a/sandbox/rover-sim/index.html
+++ b/sandbox/rover-sim/index.html
@@ -48,6 +48,7 @@
           <span class="spacer"></span>
           <button id="btn-exec" class="primary" title="スクリプトを読み込んで最初から実行 (Ctrl+Enter)">▶ 実行</button>
           <select id="sel-sample" title="サンプルをエディタに読み込んで実行"></select>
+          <button id="btn-share" title="現在のスクリプトと設定を載せた URL を作ってコピー">🔗 共有</button>
         </div>
         <div class="editors">
           <div id="editor-world" class="editor-slot hidden"></div>

--- a/sandbox/rover-sim/samples.js
+++ b/sandbox/rover-sim/samples.js
@@ -214,6 +214,11 @@ export const SAMPLES = [
   { id: 'linetrace', name: 'ライントレース', world: LINETRACE_WORLD, firmware: LINETRACE_FIRMWARE },
 ];
 
+/** スクリプトの組がどれかのサンプルと完全一致すればそのサンプルを返す (URL 共有の簡約用) */
+export function findSample(world, firmware) {
+  return SAMPLES.find((s) => s.world === world && s.firmware === firmware) || null;
+}
+
 // デフォルトサンプル (テスト・初期表示用)
 export const SAMPLE_WORLD = BASIC_WORLD;
 export const SAMPLE_FIRMWARE = BASIC_FIRMWARE;

--- a/sandbox/rover-sim/share.js
+++ b/sandbox/rover-sim/share.js
@@ -1,0 +1,86 @@
+/**
+ * URL 共有コーデック
+ *
+ * 単純な設定 (speed, view) は素のクエリパラメータ、
+ * シミュレータ側コードと探査機コードはそれぞれ別パラメータに
+ * base64url で載せる。DOM 非依存 (tests/ からも使う)。
+ *
+ * コードパラメータの形式:
+ *   "1-<base64url(deflate-raw(utf8(code)))>"  圧縮版 (通常。URL を短くするため)
+ *   "0-<base64url(utf8(code))>"               無圧縮版 (手書き・非対応環境用)
+ */
+
+export const PARAM_WORLD = 'world';
+export const PARAM_FIRMWARE = 'firmware';
+export const PARAM_SAMPLE = 'sample';
+export const PARAM_SPEED = 'speed';
+export const PARAM_VIEW = 'view';
+
+const PREFIX_DEFLATE = '1-';
+const PREFIX_PLAIN = '0-';
+
+function bytesToBase64url(bytes) {
+  let bin = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBytes(s) {
+  if (!/^[A-Za-z0-9_-]*$/.test(s)) throw new Error('base64url 以外の文字が含まれています');
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = b64.length % 4 === 2 ? '==' : b64.length % 4 === 3 ? '=' : '';
+  const bin = atob(b64 + pad);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+async function pipeThrough(bytes, transform) {
+  const stream = new Blob([bytes]).stream().pipeThrough(transform);
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** コード文字列をクエリパラメータ用の base64url ペイロードへ */
+export async function encodeText(text) {
+  const bytes = new TextEncoder().encode(String(text));
+  if (typeof CompressionStream === 'function') {
+    const compressed = await pipeThrough(bytes, new CompressionStream('deflate-raw'));
+    return PREFIX_DEFLATE + bytesToBase64url(compressed);
+  }
+  return PREFIX_PLAIN + bytesToBase64url(bytes);
+}
+
+/** encodeText の逆変換。壊れたペイロードは Error を投げる */
+export async function decodeText(payload) {
+  try {
+    let bytes;
+    if (payload.startsWith(PREFIX_DEFLATE)) {
+      const compressed = base64urlToBytes(payload.slice(PREFIX_DEFLATE.length));
+      bytes = await pipeThrough(compressed, new DecompressionStream('deflate-raw'));
+    } else if (payload.startsWith(PREFIX_PLAIN)) {
+      bytes = base64urlToBytes(payload.slice(PREFIX_PLAIN.length));
+    } else {
+      throw new Error('未知のフォーマットです');
+    }
+    return new TextDecoder().decode(bytes);
+  } catch (e) {
+    throw new Error(`共有データを読み取れませんでした (${e.message})`);
+  }
+}
+
+/**
+ * 既存のクエリ・ハッシュを除いた URL に共有パラメータを付ける。
+ * params の undefined / null / 空文字は省く。
+ */
+export function buildShareUrl(href, params) {
+  const base = href.split(/[?#]/)[0];
+  const parts = [];
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+  return parts.length > 0 ? `${base}?${parts.join('&')}` : base;
+}

--- a/sandbox/rover-sim/tests/index.html
+++ b/sandbox/rover-sim/tests/index.html
@@ -68,16 +68,18 @@
     import { renderResults } from './test-runner.js';
     import { runner as simRunner } from './sim.test.js';
     import { runner as highlightRunner } from './highlight.test.js';
+    import { runner as shareRunner } from './share.test.js';
 
     async function runAllTests() {
       const resultsDiv = document.getElementById('results');
       try {
         const simResults = await simRunner.run();
         const hlResults = await highlightRunner.run();
+        const shareResults = await shareRunner.run();
         renderResults({
-          passed: simResults.passed + hlResults.passed,
-          failed: simResults.failed + hlResults.failed,
-          suites: [...simResults.suites, ...hlResults.suites],
+          passed: simResults.passed + hlResults.passed + shareResults.passed,
+          failed: simResults.failed + hlResults.failed + shareResults.failed,
+          suites: [...simResults.suites, ...hlResults.suites, ...shareResults.suites],
         }, resultsDiv);
       } catch (error) {
         resultsDiv.innerHTML = `<p class="error">Test runner error: ${error.message}</p>`;

--- a/sandbox/rover-sim/tests/share.test.js
+++ b/sandbox/rover-sim/tests/share.test.js
@@ -1,0 +1,110 @@
+/**
+ * URL 共有コーデックのテスト
+ */
+import { createTestRunner, assert } from './test-runner.js';
+import {
+  encodeText,
+  decodeText,
+  buildShareUrl,
+  PARAM_WORLD,
+  PARAM_FIRMWARE,
+  PARAM_SAMPLE,
+} from '../share.js';
+import { SAMPLES, findSample } from '../samples.js';
+
+const { runner, describe, it } = createTestRunner();
+
+describe('encodeText / decodeText (コードの base64url 符号化)', () => {
+  it('往復でコードが一致する', async () => {
+    const src = 'function loop(rover, dt) {\n  rover.set("motor-left", 0.6);\n}';
+    assert.equal(await decodeText(await encodeText(src)), src);
+  });
+
+  it('日本語・改行・記号を含むコードも往復できる', async () => {
+    const src = '// マップ定義 🚀\nconst map = { ground(x, y) { return "#fff"; } };\n// 記号 <>&\'"`${}+/=?& ';
+    assert.equal(await decodeText(await encodeText(src)), src);
+  });
+
+  it('ペイロードは URL セーフな文字だけで構成される', async () => {
+    const payload = await encodeText('あいうえお'.repeat(100) + '+/=?&# ');
+    assert.true(/^[01]-[A-Za-z0-9_-]+$/.test(payload), `URL セーフ (${payload.slice(0, 40)}...)`);
+  });
+
+  it('圧縮が効く (繰り返しの多いコードは元のサイズより短い)', async () => {
+    const src = 'rover.set("motor-left", 0.5);\n'.repeat(200);
+    const payload = await encodeText(src);
+    assert.true(payload.length < src.length, `圧縮されている (${payload.length} < ${src.length})`);
+    assert.true(payload.startsWith('1-'), '圧縮版のプレフィックス');
+  });
+
+  it('無圧縮フォーマット (0- プレフィックス) も読める', async () => {
+    const src = 'const map = 1; // あ';
+    const b64url = btoa(String.fromCharCode(...new TextEncoder().encode(src)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    assert.equal(await decodeText(`0-${b64url}`), src);
+  });
+
+  it('壊れたペイロードはエラーになる', async () => {
+    await assert.throwsAsync(() => decodeText('garbage'));
+    await assert.throwsAsync(() => decodeText('9-AAAA'));
+    await assert.throwsAsync(() => decodeText('1-!!!!'));
+    await assert.throwsAsync(() => decodeText('1-AAAAAAAA')); // deflate として不正
+  });
+});
+
+describe('buildShareUrl', () => {
+  it('設定は素のクエリ、コードは base64 パラメータとして並ぶ', async () => {
+    const world = await encodeText('const map = {};');
+    const firmware = await encodeText('function loop() {}');
+    const url = buildShareUrl('https://sksat.net/sandbox/rover-sim/', {
+      speed: 4,
+      view: 'temp',
+      [PARAM_WORLD]: world,
+      [PARAM_FIRMWARE]: firmware,
+    });
+    assert.true(url.includes('speed=4'), '設定は読めるクエリのまま');
+    assert.true(url.includes('view=temp'));
+    assert.true(url.includes(`${PARAM_WORLD}=1-`) || url.includes(`${PARAM_WORLD}=0-`));
+    const params = new URLSearchParams(url.split('?')[1]);
+    assert.equal(await decodeText(params.get(PARAM_WORLD)), 'const map = {};');
+    assert.equal(await decodeText(params.get(PARAM_FIRMWARE)), 'function loop() {}');
+  });
+
+  it('既存のクエリ・ハッシュは除去される', () => {
+    const url = buildShareUrl('https://sksat.net/sandbox/rover-sim/?speed=1&world=old#x', { speed: 2 });
+    assert.equal(url, 'https://sksat.net/sandbox/rover-sim/?speed=2');
+  });
+
+  it('undefined / 空のパラメータは省かれる', () => {
+    const url = buildShareUrl('http://localhost:8000/a/', { speed: 4, view: undefined, world: '' });
+    assert.equal(url, 'http://localhost:8000/a/?speed=4');
+  });
+});
+
+describe('サンプル選択だけの共有', () => {
+  it('スクリプトが未編集のサンプルと一致すればサンプルを特定できる', () => {
+    const s = SAMPLES[0];
+    assert.equal(findSample(s.world, s.firmware), s);
+  });
+
+  it('少しでも編集されていたらサンプル扱いしない', () => {
+    const s = SAMPLES[0];
+    assert.equal(findSample(s.world + '\n// edit', s.firmware), null);
+    assert.equal(findSample(s.world, s.firmware + ' '), null);
+  });
+
+  it('サンプル選択だけの URL はコードを含まず sample= だけになる', () => {
+    const url = buildShareUrl('https://sksat.net/sandbox/rover-sim/', {
+      [PARAM_SAMPLE]: 'linetrace',
+      speed: 2,
+      view: 'color',
+    });
+    assert.equal(url, 'https://sksat.net/sandbox/rover-sim/?sample=linetrace&speed=2&view=color');
+    assert.false(url.includes(PARAM_WORLD + '='));
+    assert.false(url.includes(PARAM_FIRMWARE + '='));
+  });
+});
+
+export { runner };


### PR DESCRIPTION
## 概要

rover-sim の全設定を URL のクエリパラメータに載せて、リンク共有だけで再現できるようにします。

**URL フォーマット** (例):

```
?sample=linetrace&speed=4&view=temp        ← サンプル選択だけの場合
?speed=1&view=color&world=1-...&firmware=1-...   ← コードを編集している場合
```

- **単純な設定は素のクエリ**: `speed=1|2|4|8`, `view=color|temp` (読める・手で書ける)
- **コードはそれぞれ base64**: シミュレータ側コードは `world=`、探査機コードは `firmware=` に個別に載せる。形式は `1-<base64url(deflate)>` (URL を短くするため圧縮。デフォルトサンプル一式で約 2.6KB)。手書き・非対応環境用に無圧縮の `0-<base64url>` も受け付ける
- **未編集のサンプルはコードを載せない**: エディタ内容がサンプルと完全一致する場合は `sample=<id>` だけの短い URL になる。サンプル選択時はアドレスバーにも即反映される

## 挙動

- IDE ツールバーの「🔗 共有」で URL を生成 → アドレスバー反映 + クリップボードへコピー
- 起動時の復元優先順: 共有 URL > localStorage > デフォルトサンプル
- 共有 URL からの読み込みでは **localStorage を上書きしない** (訪問者が「▶ 実行」した時点で保存される)
- 「▶ 実行」やサンプル切り替えで内容が変わったら、古い共有パラメータを URL から外す
- 壊れたペイロードはコンソールにエラーを表示して通常起動にフォールバック

## テスト

コーデック (`share.js`) は DOM 非依存で 12 件のテストを追加 (往復・日本語/絵文字・URL セーフ性・圧縮効果・無圧縮形式・破損時のエラー・サンプル一致判定)。計 98 件、Node / ブラウザとも全パス。

Playwright E2E で確認済み: 共有 URL 生成とクリップボードコピー、別ブラウザコンテキストでの完全復元 (コード・速度・表示モード)、localStorage 非汚染、サンプル選択だけの短縮 URL、破損 URL のフォールバック。

> **Note**: #20 (PWM 制御) の上に積んだスタック PR です。#20 を先にマージしてから、この PR の base を gh-pages に変更してマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)